### PR TITLE
[OPS-443] do not reload synapse on startup

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -21,8 +21,8 @@ module Synapse
       raise "haproxy config section is missing" unless opts.has_key?('haproxy')
       @haproxy = Haproxy.new(opts['haproxy'])
 
-      # configuration is initially enabled to configure on first loop
-      @config_updated = true
+      # configuration is initially disabled
+      @config_updated = false
     end
 
     # start all the watchers and enable haproxy configuration

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -32,6 +32,9 @@ module Synapse
       # start all the watchers
       @service_watchers.map { |watcher| watcher.start }
 
+      # wait for them to initialize
+      sleep 1
+
       # main loop
       loops = 0
       loop do


### PR DESCRIPTION
The synapse startup does this:
* start all the watchers that update configuration (serf and dns)
* trigger a forced update
* update haproxy and reload
* sleep 2 seconds
* if there are changes, update haproxy and reload
* repeat last two

The issue is that at the time the first update haproxy is triggered, the watchers have not yet load the config from serf; we don't have default servers, and this results in watchers reporting "no backends"; the first configuration written to disk is therefore empty.

This pull request will change the behavior into:
* start all the watchers that update configuration (serf and dns)
* sleep 2 seconds
* if there are changes, update haproxy and reload
* repeat last two

This will ensure that we do not write an empty configuration to the disk, nor reload haproxy without reason.